### PR TITLE
Fix missing headers

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -81,13 +81,13 @@ async function handleRequest (request, context) {
     _time: Date.now(),
     request: {
       url: request.url,
-      headers: request.headers,
+      headers: [...request.headers].map(([key, value]) => `${key}: ${value}`),
       method: request.method,
       ...cf
     },
     response: {
       duration,
-      headers: response.headers,
+      headers: [...response.headers].map(([key, value]) => `${key}: ${value}`),
       status: response.status
     },
     worker: {


### PR DESCRIPTION
I noticed that headers are being stored in the batch to send to Axiom.

However, they are not actually being sent because `JSON.stringify` on a `Headers` object doesn't actually work because of reasons.

So I've changed it to actually show the headers, however, it might be better to omit them anyway since this way you can't really search them and they might contain sensitive data like API keys.

It might be cool to set a "whitelist" of headers (see #9) to capture for the request/response and making it in an object so it will be searchable and not burn up the fields limit in a dataset.

Thoughts?