### PR TITLE
Release 0.3.0

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -5,7 +5,7 @@ const requestHeadersToCapture = ['user-agent'];
 const responseHeadersToCapture = ['cf-cache-status', 'cf-ray'];
 
 // 8< ----------- snip ------------
-const Version = '0.2.0'
+const Version = '0.3.0'
 const axiomEndpoint = 'https://api.axiom.co'
 let workerTimestamp
 let batch = []
@@ -51,8 +51,7 @@ async function sendLogs () {
   return fetch(url, {
     signal: AbortSignal.timeout(30_000),
     method: 'POST',
-    body: logs.map(JSON.stringify).join('\n'),
-    keepalive: true,
+    body: logs.map(log => JSON.stringify(log)).join('\n'),
     headers: {
       'Content-Type': 'application/x-ndjson',
       Authorization: `Bearer ${axiomToken}`,


### PR DESCRIPTION
- Contains the fix for the timeout setting (#8)
- Contains the fix for headers not being sent (#9)

Thanks @stayallive for the contributions!

It also bumps the version to 0.3.0, removes the keepalive parameter and does a minor change in the stringify logic.